### PR TITLE
Convert string for fields marked as TIMESTAMP to Date

### DIFF
--- a/.changeset/funny-geese-retire.md
+++ b/.changeset/funny-geese-retire.md
@@ -1,0 +1,5 @@
+---
+"kysely-data-api": minor
+---
+
+Convert string for fields marked as TIMESTAMP to Date


### PR DESCRIPTION
We noticed that when using a Kysely schema using `Date`, writing and then reading the value would result in a `string` instead of a `Date`. This is a different behaviour than what we observed with the built-in postgres-dialect (where TIMESTAMP fields are returned as Date).

This adds a check for the field's `typeName` and performs the conversion to `Date` accordingly.