### PR TITLE
Upgrade kysely dependency to ^0.26.0

### DIFF
--- a/.changeset/bright-bears-walk.md
+++ b/.changeset/bright-bears-walk.md
@@ -1,0 +1,5 @@
+---
+"kysely-data-api": major
+---
+
+Upgrade kysely dependency to ^0.26.0

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
     "@changesets/cli": "^2.23.2",
     "@tsconfig/node14": "^1.0.1",
     "@types/node": "^18.14.2",
-    "kysely": "^0.23.4",
+    "kysely": "^0.26.0",
     "perf_hooks": "^0.0.1",
     "prettier": "^2.8.4",
     "vitest": "^0.18.1"
   },
   "peerDependencies": {
     "@aws-sdk/client-rds-data": "3.x",
-    "kysely": "<0.26.0"
+    "kysely": "^0.26.0"
   },
   "files": [
     "dist"

--- a/src/postgres-introspector.ts
+++ b/src/postgres-introspector.ts
@@ -66,9 +66,7 @@ export class PostgresIntrospector implements DatabaseIntrospector {
           .as("auto_incrementing"),
       ])
       // r == normal table
-      .where((qb) =>
-        qb.where("c.relkind", "=", "r").orWhere("c.relkind", "=", "v")
-      )
+      .where((qb) => qb("c.relkind", "=", "r").or("c.relkind", "=", "v"))
       .where("ns.nspname", "!~", "^pg_")
       .where("ns.nspname", "!=", "information_schema")
       // No system columns

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,7 +1022,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node@*", "@types/node@^16.11.0":
+"@types/node@*":
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.0.tgz#4b95f2327bacd1ef8f08d8ceda193039c5d7f52e"
   integrity sha512-8MLkBIYQMuhRBQzGN9875bYsOhPnf/0rgXGo66S2FemHkhbn9qtsz9ywV1iCG+vbjigE4WUNVvw37Dx+L0qsPg==
@@ -1031,6 +1031,13 @@
   version "12.20.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+
+"@types/node@^18.14.2":
+  version "18.19.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.1.tgz#e3ed7d5ab5ea21f33a4503decb2171e0d8f53070"
+  integrity sha512-mZJ9V11gG5Vp0Ox2oERpeFDl+JvCwK24PGy76vVY/UgBtjwJWc5rYBThFxmbnYOm9UPZNm6wEl/sxHt2SU7x9A==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1966,10 +1973,10 @@ kleur@^4.1.4:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
   integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
 
-kysely@^0.19.3:
-  version "0.19.3"
-  resolved "https://registry.yarnpkg.com/kysely/-/kysely-0.19.3.tgz#c103dccf464a86a33034050e1f1fc57894644118"
-  integrity sha512-hyk0zVbrT5Yx9P/IpI9zG5CFk1DXZ1d9EQsJ4UY9mp34J50r+7H96O8pmwP81yhVnmakTe93ylNq88Bd+B450w==
+kysely@^0.26.0:
+  version "0.26.3"
+  resolved "https://registry.yarnpkg.com/kysely/-/kysely-0.26.3.tgz#45fdd0153d8c9418b0ea9a6f05ed46b95ed27678"
+  integrity sha512-yWSgGi9bY13b/W06DD2OCDDHQmq1kwTGYlQ4wpZkMOJqMGCstVCFIvxCCVG4KfY1/3G0MhDAcZsip/Lw8/vJWw==
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -2279,6 +2286,11 @@ prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.8.4:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -2659,6 +2671,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
This PR is a follow-up to https://github.com/sst/kysely-data-api/pull/32.

`kysely` introduced a breaking change in their API starting with `0.26.0`. This broke the `PostgresIntrospector` class in the `kysely-data-api` package. As a result, we imposed a `peerDependency` version constraint in https://github.com/sst/kysely-data-api/pull/32 along with a minor version bump for `kysely-data-api` (which is still unreleased https://github.com/sst/kysely-data-api/pull/33)

Now, we can update our `kysely` to use `^0.26.0` and implement the fix in the `PostgresIntrospector` class, along with a major version bump.